### PR TITLE
Update main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-zookeeper_version: 3.4.12
-zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz
+zookeeper_version: 3.6.2
+zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_version}}/apache-zookeeper-{{zookeeper_version}}.tar.gz
 
 # Flag that selects if systemd or upstart will be used for the init service:
 # Note: by default Ubuntu 15.04 and later use systemd (but support switch to upstart)
-_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare(15.04, '>=') }}"
-_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version|version_compare(8.0, '>=') }}"
+_ubuntu_1504: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_version is version(15.04, '>=') }}"
+_debian_8: "{{ ansible_distribution == 'Debian' and ansible_distribution_version is version(8.0, '>=') }}"
 zookeeper_debian_systemd_enabled: "{{ _ubuntu_1504 or _debian_8 }}"
 
 zookeeper_debian_apt_install: false


### PR DESCRIPTION
version_comparedeprecated in ansible 2.9+
zookeeper tar archive renamed to apache-zookeeper